### PR TITLE
Run siad with local user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 20th May 2021
+
+* All `x86_64` debian and alpine images now run siad inside docker container
+  run as a user:group who owns `$SIA_DATA_DIR`.
+
 ## 1.5.4 (Sia 1.5.4) - 12th January 2021
 
 ## 1.5.3 (Sia 1.5.3) - 10th November 2020

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,17 @@ ARG SIA_PACKAGE="Sia-v${SIA_VERSION}-linux-amd64"
 ARG SIA_ZIP="${SIA_PACKAGE}.zip"
 ARG SIA_RELEASE="https://sia.tech/releases/${SIA_ZIP}"
 
+ARG SU_EXEC="su-exec-musl-static"
+ARG SU_EXEC_VERSION="1.3-skynetlabs-0.2.0"
+ARG SU_EXEC_RELEASE="https://github.com/SkynetLabs/su-exec/releases/download/${SU_EXEC_VERSION}/${SU_EXEC}"
+
 RUN apt-get update && \
     apt-get install -y wget unzip && \
     wget "$SIA_RELEASE" && \
     mkdir /sia && \
     unzip -j "$SIA_ZIP" "${SIA_PACKAGE}/siac" -d /sia && \
-    unzip -j "$SIA_ZIP" "${SIA_PACKAGE}/siad" -d /sia
+    unzip -j "$SIA_ZIP" "${SIA_PACKAGE}/siad" -d /sia && \
+    wget "$SU_EXEC_RELEASE"
 
 FROM debian:stretch-slim
 LABEL maintainer="NebulousLabs <devs@nebulous.tech>"
@@ -37,6 +42,13 @@ ENV SIA_MODULES gctwhr
 COPY --from=zip_downloader /sia/siac /sia/siad /usr/bin/
 COPY scripts/*.sh ./
 COPY scripts/logrotate-sia /etc/logrotate.d/sia
+
+# Preparation for su-exec
+ENV SU_EXEC="su-exec-musl-static"
+COPY --from=zip_downloader "/${SU_EXEC}" /usr/bin/
+RUN chmod +x /usr/bin/siac && \
+    chmod +x /usr/bin/siad && \
+    chmod +x "/usr/bin/${SU_EXEC}"
 
 EXPOSE 9980
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,22 @@ $ curl -A "Sia-Agent" "http://localhost:9980/consensus"
 {"synced":false,"height":4690,"currentblock":"0000000000007d656e3bb0099737892b9073259cb05883b04c6f518fbf0faffb","target":[0,0,0,0,0,2,200,179,126,85,220,153,25,190,195,228,72,53,129,181,62,124,175,60,255,90,105,68,179,16,6,71],"difficulty":"101104922300609"}
 ```
 
+## Permissions
+
+From 20th May 2021 all `x86_64` debian and alpine images run `siad` with the
+permissions as are set on mounted `$SIA_DATA_DIR` volume. Previously `siad` was
+run with `root:root` permissions. If you want to change existing permissions,
+execute:
+```sh
+docker stop <sia-container-name-or-id>
+sudo chown <user>:<group> "$SIA_DATA_DIR" # Doesn't need to be recursive
+docker start <sia-container-name-or-id>
+```
+The container will recursively change permissions of `$SIA_DATA_DIR` to wanted
+`<user>:<group>` and will run `siad` with these permissions.
+
+This enables e.g. to use local tools to inspect Sia data.
+
 ## Logs
 
 If you are interested in `siad`'s logs you can start the container with the 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -6,12 +6,17 @@ ARG SIA_PACKAGE="Sia-v${SIA_VERSION}-linux-amd64"
 ARG SIA_ZIP="${SIA_PACKAGE}.zip"
 ARG SIA_RELEASE="https://sia.tech/releases/${SIA_ZIP}"
 
+ARG SU_EXEC="su-exec-musl-static"
+ARG SU_EXEC_VERSION="1.3-skynetlabs-0.2.0"
+ARG SU_EXEC_RELEASE="https://github.com/SkynetLabs/su-exec/releases/download/${SU_EXEC_VERSION}/${SU_EXEC}"
+
 RUN apt-get update && \
     apt-get install -y wget unzip && \
     wget "$SIA_RELEASE" && \
     mkdir /sia && \
     unzip -j "$SIA_ZIP" "${SIA_PACKAGE}/siac" -d /sia && \
-    unzip -j "$SIA_ZIP" "${SIA_PACKAGE}/siad" -d /sia
+    unzip -j "$SIA_ZIP" "${SIA_PACKAGE}/siad" -d /sia && \
+    wget "$SU_EXEC_RELEASE"
 
 FROM alpine:3
 LABEL maintainer="NebulousLabs <devs@nebulous.tech>"
@@ -21,9 +26,10 @@ ARG SIA_DATA_DIR="/sia-data"
 ARG SIAD_DATA_DIR="/sia-data"
 
 # We need the mailcap package for the mime types support it provides.
+# We need the shadow package for groupmod and usermod in run.sh.
 RUN mkdir /lib64 && \
     ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2 && \
-    apk add mailcap logrotate
+    apk add mailcap logrotate shadow
 
 # Set up crond. We create a little shortcut to it, so we can work with crond the
 # same way we work with cron in Debian.
@@ -46,6 +52,13 @@ ENV SIA_MODULES gctwhr
 COPY --from=zip_downloader /sia/siac /sia/siad /usr/bin/
 COPY scripts/*.sh ./
 COPY scripts/logrotate-sia /etc/logrotate.d/sia
+
+# Preparation for su-exec
+ENV SU_EXEC="su-exec-musl-static"
+COPY --from=zip_downloader "/${SU_EXEC}" /usr/bin/
+RUN chmod +x /usr/bin/siac && \
+    chmod +x /usr/bin/siad && \
+    chmod +x "/usr/bin/${SU_EXEC}"
 
 EXPOSE 9980
 

--- a/debug/Dockerfile
+++ b/debug/Dockerfile
@@ -5,6 +5,10 @@ ENV GOOS linux
 ENV GOARCH amd64
 ENV GO111MODULE on
 
+ARG SU_EXEC="su-exec-musl-static"
+ARG SU_EXEC_VERSION="1.3-skynetlabs-0.2.0"
+ARG SU_EXEC_RELEASE="https://github.com/SkynetLabs/su-exec/releases/download/${SU_EXEC_VERSION}/${SU_EXEC}"
+
 WORKDIR /root
 
 RUN apt-get update && \
@@ -19,6 +23,9 @@ RUN apt-get update && \
     git clone https://gitlab.com/NebulousLabs/Sia.git && \
     cd Sia && \
     make release && \
+    cd - && \
+    cd / && \
+    wget "$SU_EXEC_RELEASE" && \
     cd -
 
 # Setup the actual Sia environment.
@@ -32,6 +39,13 @@ COPY scripts/logrotate-sia /etc/logrotate.d/sia
 ENV SIA_DATA_DIR "$SIA_DATA_DIR"
 ENV SIAD_DATA_DIR "$SIAD_DATA_DIR"
 ENV SIA_MODULES gctwhr
+
+# Preparation for su-exec
+ENV SU_EXEC "$SU_EXEC"
+RUN mv "/${SU_EXEC}" /usr/bin/ && \
+    chmod +x "$GOPATH/bin/siac" && \
+    chmod +x "$GOPATH/bin/siad" && \
+    chmod +x "/usr/bin/${SU_EXEC}"
 
 EXPOSE 9980
 

--- a/dev-debian/Dockerfile
+++ b/dev-debian/Dockerfile
@@ -8,6 +8,10 @@ ENV GO111MODULE on
 ARG SHA
 ARG TAG
 
+ARG SU_EXEC="su-exec-musl-static"
+ARG SU_EXEC_VERSION="1.3-skynetlabs-0.2.0"
+ARG SU_EXEC_RELEASE="https://github.com/SkynetLabs/su-exec/releases/download/${SU_EXEC_VERSION}/${SU_EXEC}"
+
 # Fetches the sha of the latest commit on the master branch that passed CI.
 # This is overriden by the manually supplied TAG and SHA values. That's done
 # in the Go code.
@@ -17,7 +21,10 @@ RUN SHA=`go run master_sha.go` && \
     git clone https://gitlab.com/NebulousLabs/Sia.git && \
     cd Sia && \
     git reset --hard $SHA && \
-    make release
+    make release && \
+    cd / && \
+    wget "$SU_EXEC_RELEASE" && \
+    cd -
 
 FROM debian:stretch-slim
 LABEL maintainer="NebulousLabs <devs@nebulous.tech>"
@@ -43,6 +50,13 @@ ENV SIA_MODULES gctwhr
 COPY --from=builder /go/bin/siac /go/bin/siad /usr/bin/
 COPY scripts/*.sh ./
 COPY scripts/logrotate-sia /etc/logrotate.d/sia
+
+# Preparation for su-exec
+ENV SU_EXEC="su-exec-musl-static"
+COPY --from=builder "/${SU_EXEC}" /usr/bin/
+RUN chmod +x /usr/bin/siac && \
+    chmod +x /usr/bin/siad && \
+    chmod +x "/usr/bin/${SU_EXEC}"
 
 EXPOSE 9980
 

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -8,6 +8,10 @@ ENV GO111MODULE on
 ARG SHA
 ARG TAG
 
+ARG SU_EXEC="su-exec-musl-static"
+ARG SU_EXEC_VERSION="1.3-skynetlabs-0.2.0"
+ARG SU_EXEC_RELEASE="https://github.com/SkynetLabs/su-exec/releases/download/${SU_EXEC_VERSION}/${SU_EXEC}"
+
 # Fetches the sha of the latest commit on the master branch that passed CI.
 # This is overriden by the manually supplied TAG and SHA values. That's done
 # in the Go code.
@@ -17,7 +21,10 @@ RUN SHA=`go run master_sha.go` && \
     git clone https://gitlab.com/NebulousLabs/Sia.git && \
     cd Sia && \
     git reset --hard $SHA && \
-    make release
+    make release && \
+    cd / && \
+    wget "$SU_EXEC_RELEASE" && \
+    cd -
 
 FROM alpine:3
 LABEL maintainer="NebulousLabs <devs@nebulous.tech>"
@@ -29,7 +36,7 @@ ARG SIAD_DATA_DIR="/sia-data"
 # We need the mailcap package for the mime types support it provides.
 RUN mkdir /lib64 && \
     ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2 && \
-    apk add mailcap logrotate
+    apk add mailcap logrotate shadow
 
 # Set up crond. We create a little shortcut to it, so we can work with crond the
 # same way we work with cron in Debian.
@@ -52,6 +59,13 @@ ENV SIA_MODULES gctwhr
 COPY --from=builder /go/bin/siac /go/bin/siad /usr/bin/
 COPY scripts/*.sh ./
 COPY scripts/logrotate-sia /etc/logrotate.d/sia
+
+# Preparation for su-exec
+ENV SU_EXEC="su-exec-musl-static"
+COPY --from=builder "/${SU_EXEC}" /usr/bin/
+RUN chmod +x /usr/bin/siac && \
+    chmod +x /usr/bin/siad && \
+    chmod +x "/usr/bin/${SU_EXEC}"
 
 EXPOSE 9980
 

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-bash -x ./build
+sudo bash -x ./build

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -16,8 +16,57 @@ siad \
 END
 )
 
-# We are using `exec` to start `siad` in order to ensure that it will be run as
-# PID 1. We need that in order to have `siad` receive OS signals (e.g. SIGTERM)
-# on container shutdown, so it can exit gracefully and no data corruption can
-# occur.
-exec $SIAD_CMD "$@"
+# Get wanted UID and GID of host user (not docker container user) from mounted
+# Sia data dir
+USER_ID=$(stat -c "%u" $SIA_DATA_DIR)
+GROUP_ID=$(stat -c "%g" $SIA_DATA_DIR)
+
+# Check if we want to run Sia as non-root user
+if [ "$(uname -m)" = "x86_64" ] && [ "$USER_ID:$GROUP_ID" != "0:0" ]; then
+  # Used username and groupname (inside docker container)
+  SIA_USER=user
+
+  # Create group if not exists
+  cat /etc/group | grep "^$SIA_USER:" > /dev/null || addgroup --gid=$GROUP_ID $SIA_USER
+
+  # Set wanted group GID (in case user existed and wanted GID has changed)
+  groupmod -g $GROUP_ID $SIA_USER
+
+  # Create user if not exists
+  cat /etc/passwd | grep "^$SIA_USER:" > /dev/null || adduser \
+    --disabled-password \
+    --gecos "" \
+    --ingroup $SIA_USER \
+    --uid $USER_ID \
+    $SIA_USER
+
+  # Set wanted user UID (in case user existed and wanted UID has changed)
+  usermod -u $USER_ID $SIA_USER
+
+  # Change sia-data ownership recursively
+  chown -R $USER_ID:$GROUP_ID $SIA_DATA_DIR
+
+  # Run as given user
+
+  # We are using `exec` to start `siad` in order to ensure that it will be run as
+  # PID 1. We need that in order to have `siad` receive OS signals (e.g. SIGTERM)
+  # on container shutdown, so it can exit gracefully and no data corruption can
+  # occur.
+  
+  # We are using `su-exec` to start `siad` in order to change a user who
+  # runs `siad` process (if we do not want to run as root).
+  echo "Running Sia with permissions of a local user: $USER_ID:$GROUP_ID"
+  exec $SU_EXEC $USER_ID:$GROUP_ID $SIAD_CMD "$@"
+else
+  # Change sia-data ownership recursively back to root
+  chown -R root:root $SIA_DATA_DIR
+
+  # Run as root
+
+  # We are using `exec` to start `siad` in order to ensure that it will be run as
+  # PID 1. We need that in order to have `siad` receive OS signals (e.g. SIGTERM)
+  # on container shutdown, so it can exit gracefully and no data corruption can
+  # occur.
+  echo "Running Sia as root"
+  exec $SIAD_CMD "$@"
+fi


### PR DESCRIPTION
Currently `siad` is executed with permissions of `root` user.
Created Sia data in mounted `$SIA_DATA_DIR` are owned by `root:root` which makes it difficult to inspect with local tools.

Debian and Alpine Dockerfiles and run.sh was updated, so that `siad` is executed with permissions of the user:group owning mounted `$SIA_DATA_DIR` volume. 