### PR TITLE
Docker raw flavor tag fix

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,7 +61,7 @@ jobs:
             type=semver,pattern={{version}},suffix=-${{ matrix.flavor }}
             type=semver,pattern={{major}}.{{minor}},suffix=-${{ matrix.flavor }}
             type=semver,pattern={{major}},suffix=-${{ matrix.flavor }}
-            type=semver,pattern=,suffix=${{ matrix.flavor }}
+            type=semver,pattern=${{ matrix.flavor }}
             type=semver,pattern={{version}},enable=${{ matrix.flavor == 'scratch' }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ matrix.flavor == 'scratch' }}
             type=semver,pattern={{major}},enable=${{ matrix.flavor == 'scratch' }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,23 +48,23 @@ jobs:
             latest=${{ matrix.flavor == 'scratch' && 'auto' || 'false' }}
           # Type 'semver' produces versions:
           # - skyd:1.5.6-flavor
-          # - skyd:1.5-flavor
-          # - skyd:1-flavor
+          # - skyd:1.5-flavor (not generated if 'major' version is 0 and 'minor' version is 0)
+          # - skyd:1-flavor (not generated if 'major' version is 0)
           # - skyd:flavor
           # Type 'semver' also produces 'latest' and unsuffixed tags for 'scratch' flavor:
           # - skyd:latest
           # - skyd:1.5.6
-          # - skyd:1.5
-          # - skyd:1
+          # - skyd:1.5 (not generated if 'major' version is 0 and 'minor' version is 0)
+          # - skyd:1 (not generated if 'major' version is 0)
           # Type 'sha' produces local image on pull requests, not published on dockerhub
           tags: |
             type=semver,pattern={{version}},suffix=-${{ matrix.flavor }}
-            type=semver,pattern={{major}}.{{minor}},suffix=-${{ matrix.flavor }}
-            type=semver,pattern={{major}},suffix=-${{ matrix.flavor }}
+            type=semver,pattern={{major}}.{{minor}},suffix=-${{ matrix.flavor }},enable=${{ !startsWith(github.ref, 'refs/tags/v0.0.') }}
+            type=semver,pattern={{major}},suffix=-${{ matrix.flavor }},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
             type=semver,pattern=${{ matrix.flavor }}
             type=semver,pattern={{version}},enable=${{ matrix.flavor == 'scratch' }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ matrix.flavor == 'scratch' }}
-            type=semver,pattern={{major}},enable=${{ matrix.flavor == 'scratch' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ matrix.flavor == 'scratch' }},enable=${{ !startsWith(github.ref, 'refs/tags/v0.0.') }}
+            type=semver,pattern={{major}},enable=${{ matrix.flavor == 'scratch' && !startsWith(github.ref, 'refs/tags/v0.') }}
             type=sha,enable=${{ github.event_name == 'pull_request' }}
       - uses: docker/login-action@v2
         # authenticate on dockerhub only when we are going to publish


### PR DESCRIPTION
- fix configuration of raw flavor tags (`skyd:scratch` and `skyd:bullseye-slim`) - was malfunctioning for `-beta` versions
  - it will work now like `latest` tag where `latest` is not getting updated on beta releases
  - previously empty pattern for beta releases was replaced with full version and it produces really strangely concatenated tag
- do not generate major-only tag if `major` is zero (ie. do not generate `skyd:0` from `v0.3.1`)
  - standard practice, does not apply to us here really because skyd is already at 1.5.10 but that's a cleanup if we decide to copy this workflow
- do not generate major.minor-only tag if `major` and `minor` are zero (ie. do not generate `skyd:0.0` from `v0.0.1`)
  - standard practice, does not apply to us here really because skyd is already at 1.5.10 but that's a cleanup if we decide to copy this workflow