### PR TITLE
Readme cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Skynet apps transform what’s possible on the web. Beyond protecting privacy, d
 
 # How to use this image
 
+<!-- this direct link is here because dockerhub might have outdated version of readme on repository page -->
+
 See [How To Use This Image](https://github.com/skynetlabs/docker-skyd/blob/main/README.md#how-to-use-this-image) on GitHub for up-to-date documentation.
 
 ### Startup command

--- a/README.md
+++ b/README.md
@@ -66,10 +66,6 @@ It is recommended to store your wallet password in `SIA_WALLET_PASSWORD` env var
 
 Initially your wallet password is your seed phrase but you can change it using built in [cli](#cli-client-skyc) command `skyc wallet change-password`.
 
-## Default docker command
-
-Docker command defaults to `--disable-api-security --api-addr :9980 --modules gtcwra` which is best suited for running skyd as a part of Skynet Webportal stack. In case that does not fit your use case, you are free to override the command as necessary.
-
 ## Logs rotation
 
 Skyd produces multiple log files that are persisted to disk in append mode. These log files can grow significantly and it is recommended to rotate them based on size of the files.

--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@
 
 # Supported tags and respective `Dockerfile` links
 
-- [`1.5.5-scratch`, `1.5-scratch`, `1-scratch`, `scratch`, `latest`](https://github.com/SkynetLabs/docker-skyd/blob/main/scratch/Dockerfile)
-- [`1.5.5-bullseye-slim`, `1.5-bullseye-slim`, `1-bullseye-slim`, `bullseye-slim`](https://github.com/SkynetLabs/docker-skyd/blob/main/bullseye-slim/Dockerfile)
+_no image released yet_
+
+<!-- - [`1.5.5-scratch`, `1.5-scratch`, `1-scratch`, `scratch`, `latest`](https://github.com/SkynetLabs/docker-skyd/blob/main/scratch/Dockerfile) -->
+<!-- - [`1.5.5-bullseye-slim`, `1.5-bullseye-slim`, `1-bullseye-slim`, `bullseye-slim`](https://github.com/SkynetLabs/docker-skyd/blob/main/bullseye-slim/Dockerfile) -->
 
 # What is Skynet?
 


### PR DESCRIPTION
- do not list dockerhub release versions until we actually release first one
- remove section about "default docker command" since we removed the default from the images in https://github.com/SkynetLabs/docker-skyd/commit/9c720b2869e25dfd34c471b68667e499d4461515